### PR TITLE
add version, publicKey in registration, keyHandle in signature

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
 	"name": "Virtual FIDO U2F Token Extension",
 	"description": "This exposes a window.u2f object to Chrome, mimicking the way the standard extension would behave with a hardware token connected.",
 	"author": "Moritz Platt",
-	"version": "0.0.1",
+	"version": "0.0.2",
 	"key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzO5KxMDzpJ2x3t0BINb0CVHldUvgJYMPrv8KwgPGE+iuUYDHZdPPUwYgtztrUXjkOcMOCfgVkgX/y2djvmR4iXvoo9aSwd2Z41p+eSNvs7o62J+FCLlRI0dYjAAaZu+JOSUq+6POyN9hddq48UJ4Aan47v4WjNzd15kq8gv3+2ETyx4nd8DNUvzWJQW6iFOvMvotVTbhl3BWmZLt9rnntD3AF5F/7DjcXlQTaxtWoVkuW40xp73lAJzitlOHGrvVxQeWR8+qn5NShai3uk9yt8k7OD9WBd/qfiHwRZotElOIaVWQW/e4prs3Y9NIkHHS03gz7pvYzQDkYUID10su/QIDAQAB",
 	"icons": {
 		"16": "assets/icon/icon16.png",


### PR DESCRIPTION
Hello,

According to the U2F specification, the field `version` is required for the registration response, and the `keyHandle` is also required for the signature response. 

I added these fields in the different messages. 

The yubikeys also provide a public key during the registration. To mimic this behaviour, I also added this field. 

